### PR TITLE
feat: Add test fixtures and dependencies

### DIFF
--- a/verdict-backend/app/config.py
+++ b/verdict-backend/app/config.py
@@ -14,7 +14,11 @@ class Settings(BaseSettings):
 
     @property
     def database_url(self) -> str:
-        return f"postgresql+psycopg2://{self.database_user}:{self.database_password}@{self.database_host}:{self.database_port}/{self.database_name}"
+        return (
+            f"postgresql+psycopg2://"
+            f"{self.database_user}:{self.database_password.get_secret_value()}"
+            f"@{self.database_host}:{self.database_port}/{self.database_name}"
+        )
 
     debug: bool = False
     log_level: str = "info"

--- a/verdict-backend/justfile
+++ b/verdict-backend/justfile
@@ -11,11 +11,11 @@ dev:
 
 # Run tests
 test *ARGS:
-    uv run pytest --disable-plugin-autoload {{ARGS}}
+    DATABASE_NAME=$DATABASE_NAME_TEST uv run pytest --disable-plugin-autoload -p asyncio {{ARGS}}
 
 # Run tests with coverage
 test-cov *ARGS:
-    uv run pytest --disable-plugin-autoload -p pytest_cov --cov=app --cov-report=html --cov-report=term-missing {{ARGS}}
+    DATABASE_NAME=$DATABASE_NAME_TEST uv run pytest --disable-plugin-autoload -p asyncio -p pytest_cov --cov=app --cov-report=html --cov-report=term-missing {{ARGS}}
 
 # Format code
 format:

--- a/verdict-backend/pyproject.toml
+++ b/verdict-backend/pyproject.toml
@@ -116,6 +116,7 @@ testpaths = ["tests"]
 python_files = ["test_*.py"]
 python_functions = ["test_*"]
 addopts = "-v --tb=short --strict-markers"
+asyncio_mode = "auto"
 markers = [
     "slow: marks tests as slow (deselect with '-m \"not slow\"')",
     "integration: marks tests as integration tests",
@@ -153,9 +154,14 @@ exclude_lines = [
 
 [dependency-groups]
 dev = [
+    {include-group = "test"},
     "mypy>=1.19.1",
-    "pytest-cov>=7.0.0",
 ]
 test = [
+    "pytest>=9.0.0",
+    "pytest-asyncio>=0.24.0",
     "pytest-cov>=7.0.0",
+    "httpx>=0.28.0",
+    "factory-boy>=3.3.0",
+    "faker>=30.0.0",
 ]

--- a/verdict-backend/tests/conftest.py
+++ b/verdict-backend/tests/conftest.py
@@ -1,0 +1,42 @@
+from collections.abc import AsyncGenerator, Generator
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+from sqlmodel import Session
+
+from app.db import engine, get_session
+from app.main import app
+from tests.factories import BaseModelFactory
+
+
+@pytest.fixture
+def db_session() -> Generator[Session, None, None]:
+    """Provide a transactional database session that rolls back after each test."""
+    connection = engine.connect()
+    transaction = connection.begin()
+    session = Session(bind=connection)
+    BaseModelFactory.set_session(session)
+
+    yield session
+
+    session.close()
+    transaction.rollback()
+    connection.close()
+
+
+@pytest.fixture
+async def app_client(db_session: Session) -> AsyncGenerator[AsyncClient, None]:
+    """Provide an async HTTP client with the DB dependency overridden."""
+
+    def _override_get_session() -> Generator[Session, None, None]:
+        yield db_session
+
+    app.dependency_overrides[get_session] = _override_get_session
+
+    async with AsyncClient(
+        transport=ASGITransport(app=app),
+        base_url="http://test",
+    ) as client:
+        yield client
+
+    app.dependency_overrides.clear()

--- a/verdict-backend/tests/factories/__init__.py
+++ b/verdict-backend/tests/factories/__init__.py
@@ -1,0 +1,19 @@
+import factory
+from sqlmodel import Session
+
+
+class BaseModelFactory(factory.alchemy.SQLAlchemyModelFactory):
+    """Base factory for all SQLModel-based factories.
+
+    Subclasses set their own `model` in ``class Meta``.
+    The session is injected at test time via ``BaseModelFactory.set_session()``.
+    """
+
+    class Meta:
+        abstract = True
+        sqlalchemy_session_persistence = "flush"
+
+    @classmethod
+    def set_session(cls, session: Session) -> None:
+        """Bind all factories to the given test session."""
+        cls._meta.sqlalchemy_session = session

--- a/verdict-backend/tests/test_smoke.py
+++ b/verdict-backend/tests/test_smoke.py
@@ -1,0 +1,15 @@
+from httpx import AsyncClient
+from sqlalchemy import text
+from sqlmodel import Session
+
+
+async def test_root_returns_200(app_client: AsyncClient) -> None:
+    """Verify the app_client fixture can hit the root endpoint."""
+    response = await app_client.get("/")
+    assert response.status_code == 200
+
+
+def test_db_session_executes_query(db_session: Session) -> None:
+    """Verify the db_session fixture connects to verdict_test."""
+    result = db_session.exec(text("SELECT 1")).scalar()
+    assert result == 1

--- a/verdict-backend/uv.lock
+++ b/verdict-backend/uv.lock
@@ -955,10 +955,20 @@ test = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "factory-boy" },
+    { name = "faker" },
+    { name = "httpx" },
     { name = "mypy" },
+    { name = "pytest" },
+    { name = "pytest-asyncio" },
     { name = "pytest-cov" },
 ]
 test = [
+    { name = "factory-boy" },
+    { name = "faker" },
+    { name = "httpx" },
+    { name = "pytest" },
+    { name = "pytest-asyncio" },
     { name = "pytest-cov" },
 ]
 
@@ -992,10 +1002,22 @@ provides-extras = ["dev", "test", "production"]
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "factory-boy", specifier = ">=3.3.0" },
+    { name = "faker", specifier = ">=30.0.0" },
+    { name = "httpx", specifier = ">=0.28.0" },
     { name = "mypy", specifier = ">=1.19.1" },
+    { name = "pytest", specifier = ">=9.0.0" },
+    { name = "pytest-asyncio", specifier = ">=0.24.0" },
     { name = "pytest-cov", specifier = ">=7.0.0" },
 ]
-test = [{ name = "pytest-cov", specifier = ">=7.0.0" }]
+test = [
+    { name = "factory-boy", specifier = ">=3.3.0" },
+    { name = "faker", specifier = ">=30.0.0" },
+    { name = "httpx", specifier = ">=0.28.0" },
+    { name = "pytest", specifier = ">=9.0.0" },
+    { name = "pytest-asyncio", specifier = ">=0.24.0" },
+    { name = "pytest-cov", specifier = ">=7.0.0" },
+]
 
 [[package]]
 name = "watchfiles"


### PR DESCRIPTION
Includes `pytest-asyncio` and other testing utilities for better testability.
Configures `pytest` to use `asyncio_mode = "auto"`. Adds database session and application client fixtures for testing. Sets up base factory for SQLModel models.
Introduces a smoke test to verify basic application and database connectivity.
Updates password handling in database URL to use `get_secret_value()`.

Implements #1, fixes #17 