### PR TITLE
feat: Split Settings into Database and Operational Subsets

### DIFF
--- a/verdict-backend/alembic/env.py
+++ b/verdict-backend/alembic/env.py
@@ -7,7 +7,7 @@ from sqlmodel import SQLModel
 
 import app.models  # noqa: F401  # register models for autogenerate
 from alembic import context
-from app.config import get_settings
+from app.config import get_database_settings
 
 # this is the Alembic Config object, which provides
 # access to the values within the .ini file in use.
@@ -38,8 +38,8 @@ def run_migrations_offline() -> None:
     script output.
 
     """
-    settings = get_settings()
-    url = settings.database_url
+    db_settings = get_database_settings()
+    url = db_settings.database_url
     context.configure(
         url=url,
         target_metadata=target_metadata,
@@ -58,9 +58,9 @@ def run_migrations_online() -> None:
     and associate a connection with the context.
 
     """
-    settings = get_settings()
+    db_settings = get_database_settings()
     connectable = engine_from_config(
-        {"sqlalchemy.url": settings.database_url},
+        {"sqlalchemy.url": db_settings.database_url},
         prefix="sqlalchemy.",
         poolclass=pool.NullPool,
     )

--- a/verdict-backend/alembic/env.py
+++ b/verdict-backend/alembic/env.py
@@ -7,7 +7,7 @@ from sqlmodel import SQLModel
 
 import app.models  # noqa: F401  # register models for autogenerate
 from alembic import context
-from app.config import get_database_settings
+from app.database_config import get_database_settings
 
 # this is the Alembic Config object, which provides
 # access to the values within the .ini file in use.

--- a/verdict-backend/app/config.py
+++ b/verdict-backend/app/config.py
@@ -1,31 +1,8 @@
-# app/config.py
 from functools import lru_cache
 
-from pydantic import Field, SecretStr
-from pydantic_settings import BaseSettings, SettingsConfigDict
+from pydantic import Field
 
-
-class DatabaseSettings(BaseSettings):
-    model_config = SettingsConfigDict(
-        env_file=".env",
-        env_file_encoding="utf-8",
-        case_sensitive=False,
-        extra="allow",
-    )
-
-    database_host: str = Field(default=...)
-    database_port: int = Field(default=...)
-    database_name: str = Field(default=...)
-    database_user: str = Field(default=...)
-    database_password: SecretStr = Field(default=...)
-
-    @property
-    def database_url(self) -> str:
-        return (
-            f"postgresql+psycopg2://"
-            f"{self.database_user}:{self.database_password.get_secret_value()}"
-            f"@{self.database_host}:{self.database_port}/{self.database_name}"
-        )
+from app.database_config import DatabaseSettings
 
 
 class Settings(DatabaseSettings):

--- a/verdict-backend/app/config.py
+++ b/verdict-backend/app/config.py
@@ -5,7 +5,7 @@ from pydantic import Field, SecretStr
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
-class Settings(BaseSettings):
+class DatabaseSettings(BaseSettings):
     model_config = SettingsConfigDict(
         env_file=".env",
         env_file_encoding="utf-8",
@@ -19,9 +19,6 @@ class Settings(BaseSettings):
     database_user: str = Field(default=...)
     database_password: SecretStr = Field(default=...)
 
-    asset_inventory_url: str = Field(default=...)
-    cmdb_url: str = Field(default=...)
-
     @property
     def database_url(self) -> str:
         return (
@@ -30,8 +27,18 @@ class Settings(BaseSettings):
             f"@{self.database_host}:{self.database_port}/{self.database_name}"
         )
 
+
+class Settings(DatabaseSettings):
+    asset_inventory_url: str = Field(default=...)
+    cmdb_url: str = Field(default=...)
+
     debug: bool = False
     log_level: str = "info"
+
+
+@lru_cache
+def get_database_settings() -> DatabaseSettings:
+    return DatabaseSettings()
 
 
 @lru_cache

--- a/verdict-backend/app/config.py
+++ b/verdict-backend/app/config.py
@@ -14,11 +14,6 @@ class Settings(DatabaseSettings):
 
 
 @lru_cache
-def get_database_settings() -> DatabaseSettings:
-    return DatabaseSettings()
-
-
-@lru_cache
 def get_settings() -> Settings:
     """Cached settings instance"""
     return Settings()

--- a/verdict-backend/app/database_config.py
+++ b/verdict-backend/app/database_config.py
@@ -1,0 +1,32 @@
+from functools import lru_cache
+
+from pydantic import Field, SecretStr
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+
+class DatabaseSettings(BaseSettings):
+    model_config = SettingsConfigDict(
+        env_file=".env",
+        env_file_encoding="utf-8",
+        case_sensitive=False,
+        extra="allow",
+    )
+
+    database_host: str = Field(default=...)
+    database_port: int = Field(default=...)
+    database_name: str = Field(default=...)
+    database_user: str = Field(default=...)
+    database_password: SecretStr = Field(default=...)
+
+    @property
+    def database_url(self) -> str:
+        return (
+            f"postgresql+psycopg2://"
+            f"{self.database_user}:{self.database_password.get_secret_value()}"
+            f"@{self.database_host}:{self.database_port}/{self.database_name}"
+        )
+
+
+@lru_cache
+def get_database_settings() -> DatabaseSettings:
+    return DatabaseSettings()


### PR DESCRIPTION
Implements #27 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Separated database-specific configuration into its own settings model with a cached accessor for consistent DB connection handling.
  * Application settings now expose external service URLs (asset inventory, CMDB) and delegate DB info to the new database config.
  * Migration tooling updated to read the database URL from the centralized database settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->